### PR TITLE
Fix search bar microservice generation

### DIFF
--- a/src/data/systemComponents.ts
+++ b/src/data/systemComponents.ts
@@ -558,16 +558,6 @@ export const systemComponents = [
     category: 'Compute',
   },
   {
-    id: 'microservice',
-    name: 'Microservice',
-    icon: 'microservice',
-    color: 'bg-gradient-to-br from-slate-50 to-slate-100 border-slate-200',
-    hoverColor:
-      'hover:from-slate-100 hover:to-slate-200 hover:border-slate-300',
-    description: 'Service component',
-    category: 'Compute',
-  },
-  {
     id: 'distributed-lock-manager',
     name: 'Distributed Lock Manager',
     icon: 'distributed-lock-manager',


### PR DESCRIPTION
Remove duplicate 'microservice' component definition to prevent spurious component generation on search.

The duplicate object with id 'microservice' in `src/data/systemComponents.ts` caused React to repeatedly reconcile two entries with the same key. This led to an extra 'Microservice' component appearing in the search results with every re-render triggered by typing in the search bar.